### PR TITLE
feat(python-app): add PodDisruptionBudget support

### DIFF
--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -18,7 +18,7 @@ name: cluster
 description: Deploys and manages a CloudNativePG cluster and its associated resources.
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
-version: 0.3.4
+version: 0.3.5
 sources:
   - https://github.com/cloudnative-pg/charts
 keywords:

--- a/charts/cnpg-cluster/templates/_helpers.tpl
+++ b/charts/cnpg-cluster/templates/_helpers.tpl
@@ -144,3 +144,49 @@ Postgres GID
     {{- 26 -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Validate PodDisruptionBudget configuration for a pooler.
+Expects a dict with: "pooler" (the pooler entry) and "instances" (effective instance count).
+*/}}
+{{- define "cluster.validatePoolerPdb" -}}
+{{- $pooler := .pooler }}
+{{- $instances := int .instances }}
+
+{{/* Validate: at least one of maxUnavailable or minAvailable must be set */}}
+{{- if and (not (hasKey $pooler.podDisruptionBudget "maxUnavailable")) (not (hasKey $pooler.podDisruptionBudget "minAvailable")) }}
+  {{ fail (printf "pooler '%s': podDisruptionBudget is enabled but neither maxUnavailable nor minAvailable is set. Please set exactly one." $pooler.name) }}
+{{- end }}
+
+{{/* Validate: maxUnavailable and minAvailable are mutually exclusive */}}
+{{- if and (hasKey $pooler.podDisruptionBudget "maxUnavailable") (hasKey $pooler.podDisruptionBudget "minAvailable") }}
+  {{ fail (printf "pooler '%s': podDisruptionBudget.maxUnavailable and minAvailable are mutually exclusive. Please set only one." $pooler.name) }}
+{{- end }}
+
+{{/* Validate maxUnavailable: instances - maxUnavailable must be > 0 */}}
+{{- if hasKey $pooler.podDisruptionBudget "maxUnavailable" }}
+  {{- if or (kindIs "float64" $pooler.podDisruptionBudget.maxUnavailable) (kindIs "int64" $pooler.podDisruptionBudget.maxUnavailable) }}
+    {{- $val := int $pooler.podDisruptionBudget.maxUnavailable }}
+    {{- if le $val 0 }}
+      {{ fail (printf "pooler '%s': podDisruptionBudget.maxUnavailable must be a positive integer, got %d" $pooler.name $val) }}
+    {{- end }}
+    {{- if ge $val $instances }}
+      {{ fail (printf "pooler '%s': podDisruptionBudget.maxUnavailable (%d) must be strictly less than instances (%d). Difference must be > 0." $pooler.name $val $instances) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/* Validate minAvailable: instances - minAvailable must be > 0 */}}
+{{- if hasKey $pooler.podDisruptionBudget "minAvailable" }}
+  {{- if or (kindIs "float64" $pooler.podDisruptionBudget.minAvailable) (kindIs "int64" $pooler.podDisruptionBudget.minAvailable) }}
+    {{- $val := int $pooler.podDisruptionBudget.minAvailable }}
+    {{- if le $val 0 }}
+      {{ fail (printf "pooler '%s': podDisruptionBudget.minAvailable must be a positive integer, got %d" $pooler.name $val) }}
+    {{- end }}
+    {{- if ge $val $instances }}
+      {{ fail (printf "pooler '%s': podDisruptionBudget.minAvailable (%d) must be strictly less than instances (%d). Difference must be > 0." $pooler.name $val $instances) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/cnpg-cluster/templates/pooler-pdb.yaml
+++ b/charts/cnpg-cluster/templates/pooler-pdb.yaml
@@ -1,0 +1,23 @@
+{{- range .Values.poolers }}
+{{- if and .podDisruptionBudget .podDisruptionBudget.enabled }}
+{{- include "cluster.validatePoolerPdb" (dict "pooler" . "instances" .instances) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cluster.fullname" $ }}-pooler-{{ .name }}
+  namespace: {{ include "cluster.namespace" $ }}
+  labels:
+    {{- include "cluster.labels" $ | nindent 4 }}
+spec:
+  {{- if hasKey .podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if hasKey .podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      cnpg.io/poolerName: {{ include "cluster.fullname" $ }}-pooler-{{ .name }}
+{{- end }}
+{{- end }}

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -490,6 +490,11 @@ poolers: []
   #   # -- Custom PgBouncer service template.
   #   # Use to override service type, ports, etc.
   #   serviceTemplate: {}
+  #   # -- PodDisruptionBudget for this pooler
+  #   # Only one of maxUnavailable or minAvailable should be set
+  #   podDisruptionBudget:
+  #     enabled: false
+  #     minAvailable: 1
   # -
   #   # -- Pooler name
   #   name: ro
@@ -515,3 +520,8 @@ poolers: []
   #   # -- Custom PgBouncer service template.
   #   # Use to override service type, ports, etc.
   #   serviceTemplate: {}
+  #   # -- PodDisruptionBudget for this pooler
+  #   # Only one of maxUnavailable or minAvailable should be set
+  #   podDisruptionBudget:
+  #     enabled: false
+  #     minAvailable: 1

--- a/charts/python-app/Chart.yaml
+++ b/charts/python-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.50
+version: 0.1.51
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/python-app/Chart.yaml
+++ b/charts/python-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.51
+version: 0.1.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: cluster
-    version: 0.3.4
+    version: 0.3.5
     repository: https://nw-tech.github.io/public_charts/
     condition: cluster.enabled
   - name: celery-worker

--- a/charts/python-app/templates/_helpers.tpl
+++ b/charts/python-app/templates/_helpers.tpl
@@ -60,3 +60,53 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate PodDisruptionBudget configuration.
+Called from pdb.yaml when podDisruptionBudget is enabled.
+*/}}
+{{- define "app.validatePdb" -}}
+
+{{/* Determine effective replica count */}}
+{{- $effectiveReplicas := int .Values.replicaCount }}
+{{- if .Values.autoscaling.enabled }}
+  {{- $effectiveReplicas = int .Values.autoscaling.minReplicas }}
+{{- end }}
+
+{{/* Validate: at least one of maxUnavailable or minAvailable must be set */}}
+{{- if and (not (hasKey .Values.podDisruptionBudget "maxUnavailable")) (not (hasKey .Values.podDisruptionBudget "minAvailable")) }}
+  {{ fail "podDisruptionBudget is enabled but neither maxUnavailable nor minAvailable is set. Please set exactly one." }}
+{{- end }}
+
+{{/* Validate: maxUnavailable and minAvailable are mutually exclusive */}}
+{{- if and (hasKey .Values.podDisruptionBudget "maxUnavailable") (hasKey .Values.podDisruptionBudget "minAvailable") }}
+  {{ fail "podDisruptionBudget: maxUnavailable and minAvailable are mutually exclusive. Please set only one." }}
+{{- end }}
+
+{{/* Validate maxUnavailable: replicaCount - maxUnavailable must be > 0 */}}
+{{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  {{- if kindIs "float64" .Values.podDisruptionBudget.maxUnavailable }}
+    {{- $maxUnavailable := int .Values.podDisruptionBudget.maxUnavailable }}
+    {{- if le $maxUnavailable 0 }}
+      {{ fail (printf "podDisruptionBudget.maxUnavailable must be a positive integer, got %d" $maxUnavailable) }}
+    {{- end }}
+    {{- if ge $maxUnavailable $effectiveReplicas }}
+      {{ fail (printf "podDisruptionBudget.maxUnavailable (%d) must be strictly less than the effective replica count (%d). Difference must be > 0." $maxUnavailable $effectiveReplicas) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/* Validate minAvailable: replicaCount - minAvailable must be > 0 */}}
+{{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  {{- if kindIs "float64" .Values.podDisruptionBudget.minAvailable }}
+    {{- $minAvailable := int .Values.podDisruptionBudget.minAvailable }}
+    {{- if le $minAvailable 0 }}
+      {{ fail (printf "podDisruptionBudget.minAvailable must be a positive integer, got %d" $minAvailable) }}
+    {{- end }}
+    {{- if ge $minAvailable $effectiveReplicas }}
+      {{ fail (printf "podDisruptionBudget.minAvailable (%d) must be strictly less than the effective replica count (%d). Difference must be > 0." $minAvailable $effectiveReplicas) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/python-app/templates/_helpers.tpl
+++ b/charts/python-app/templates/_helpers.tpl
@@ -84,8 +84,9 @@ Called from pdb.yaml when podDisruptionBudget is enabled.
 {{- end }}
 
 {{/* Validate maxUnavailable: replicaCount - maxUnavailable must be > 0 */}}
+{{/* Numeric check handles both float64 (YAML values files) and int64 (--set flag) */}}
 {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
-  {{- if kindIs "float64" .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if or (kindIs "float64" .Values.podDisruptionBudget.maxUnavailable) (kindIs "int64" .Values.podDisruptionBudget.maxUnavailable) }}
     {{- $maxUnavailable := int .Values.podDisruptionBudget.maxUnavailable }}
     {{- if le $maxUnavailable 0 }}
       {{ fail (printf "podDisruptionBudget.maxUnavailable must be a positive integer, got %d" $maxUnavailable) }}
@@ -98,7 +99,7 @@ Called from pdb.yaml when podDisruptionBudget is enabled.
 
 {{/* Validate minAvailable: replicaCount - minAvailable must be > 0 */}}
 {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
-  {{- if kindIs "float64" .Values.podDisruptionBudget.minAvailable }}
+  {{- if or (kindIs "float64" .Values.podDisruptionBudget.minAvailable) (kindIs "int64" .Values.podDisruptionBudget.minAvailable) }}
     {{- $minAvailable := int .Values.podDisruptionBudget.minAvailable }}
     {{- if le $minAvailable 0 }}
       {{ fail (printf "podDisruptionBudget.minAvailable must be a positive integer, got %d" $minAvailable) }}

--- a/charts/python-app/templates/pdb.yaml
+++ b/charts/python-app/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- include "app.validatePdb" . }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/python-app/values.yaml
+++ b/charts/python-app/values.yaml
@@ -236,6 +236,13 @@ autoscaling:
   targetCPUUtilizationPercentage: 90
   targetMemoryUtilizationPercentage: 90
 
+podDisruptionBudget:
+  enabled: false
+  # Only one of maxUnavailable or minAvailable should be set
+  # Accepts an integer or a percentage string (e.g. "50%")
+  # maxUnavailable: 1
+  # minAvailable: 1
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary

### python-app chart (v0.1.52)
- Add a `PodDisruptionBudget` template gated by `podDisruptionBudget.enabled` (default: `false`)
- Add `app.validatePdb` named template in `_helpers.tpl` that enforces:
  - Exactly one of `maxUnavailable` or `minAvailable` must be set (mutually exclusive)
  - The budget must be strictly less than the effective replica count (`replicaCount`, or `autoscaling.minReplicas` when HPA is enabled)
  - Numeric validation is skipped for percentage strings (e.g. `"50%"`), which Kubernetes validates at apply time
  - Handles both `float64` (YAML values files) and `int64` (`--set` flag) integer types

### cnpg-cluster chart (v0.3.5)
- Add `pooler-pdb.yaml` template — creates a standalone `PodDisruptionBudget` per pooler (the CNPG Pooler CRD does not support `enablePDB`, so the operator does not create PDBs for PgBouncer pods)
- Add `cluster.validatePoolerPdb` named template with the same validation logic, scoped per pooler
- PDB selector uses the `cnpg.io/poolerName` label set by the CNPG operator on pooler pods
- Cluster instances already have PDB via `enablePDB: true` (operator-managed, no changes needed)

### Version bumps
- cnpg-cluster: `0.3.4` → `0.3.5`
- python-app: `0.1.50` → `0.1.52` (includes updated cluster dependency)

## PDB Usage

```yaml
# python-app deployment PDB
podDisruptionBudget:
  enabled: true
  maxUnavailable: 1

# cnpg pooler PDB (per pooler entry)
poolers:
  - name: rw
    instances: 3
    podDisruptionBudget:
      enabled: true
      minAvailable: 1
```

## Test plan

### python-app PDB
- [x] `helm template` with PDB disabled — no PDB resource rendered
- [x] Valid `maxUnavailable` / `minAvailable` with sufficient replicas
- [x] Percentage string value — PDB renders, numeric validation skipped
- [x] `maxUnavailable >= replicaCount` — `fail` with clear error
- [x] Both fields set — `fail` with mutual exclusivity message
- [x] Neither field set — `fail` with missing field message
- [x] Autoscaling enabled — validates against `minReplicas`

### cnpg-cluster pooler PDB
- [x] Pooler PDB renders correctly with `minAvailable` / `maxUnavailable`
- [x] No PDB when `podDisruptionBudget` not set on pooler
- [x] `minAvailable >= instances` — `fail` with pooler name in error
- [x] Both fields set — `fail`
- [x] Neither field set — `fail`
- [x] Cluster `enablePDB: true` still rendered in cluster.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)