### PR TITLE
feat(cnpg-cluster): add replica rebuild from backup object store

### DIFF
--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -18,7 +18,7 @@ name: cluster
 description: Deploys and manages a CloudNativePG cluster and its associated resources.
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
-version: 0.3.5
+version: 0.4.0
 sources:
   - https://github.com/cloudnative-pg/charts
 keywords:

--- a/charts/cnpg-cluster/templates/_bootstrap.tpl
+++ b/charts/cnpg-cluster/templates/_bootstrap.tpl
@@ -26,6 +26,15 @@ bootstrap:
           {{- end -}}
       {{- end -}}
     {{- end }}
+{{- if and .Values.backups.enabled .Values.backups.replicaFromBackup }}
+
+externalClusters:
+  - name: objectStoreCluster
+    barmanObjectStore:
+      serverName: {{ include "cluster.fullname" . }}
+      {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.backups "secretPrefix" "backup" -}}
+      {{- include "cluster.barmanObjectStoreConfig" $d | nindent 4 }}
+{{- end }}
 {{- else if eq .Values.mode "recovery" -}}
 bootstrap:
 {{- if eq .Values.recovery.method "pg_basebackup" }}

--- a/charts/cnpg-cluster/values.schema.json
+++ b/charts/cnpg-cluster/values.schema.json
@@ -164,6 +164,9 @@
                             "type": "integer"
                         }
                     }
+                },
+                "replicaFromBackup": {
+                    "type": "boolean"
                 }
             }
         },

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -455,6 +455,13 @@ backups:
   # -- Retention policy for backups
   retentionPolicy: "30d"
 
+  # -- When enabled and backups are configured, adds the backup object store as an
+  # externalCluster source. This allows CNPG to rebuild replicas from the backup
+  # instead of using pg_basebackup from the primary.
+  # Note: On initial cluster creation, the first backup must complete before
+  # replicas can use this feature. CNPG falls back to pg_basebackup if no backup exists.
+  replicaFromBackup: false
+
 imageCatalog:
   # -- Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored.
   create: true

--- a/charts/python-app/Chart.yaml
+++ b/charts/python-app/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: cluster
-    version: 0.3.5
+    version: 0.4.0
     repository: https://nw-tech.github.io/public_charts/
     condition: cluster.enabled
   - name: celery-worker

--- a/charts/python-app/values.yaml
+++ b/charts/python-app/values.yaml
@@ -79,6 +79,7 @@ cluster:
 
   backups:
     enabled: true
+    replicaFromBackup: true
     secret:
       create: false
     provider: google


### PR DESCRIPTION
## Summary
- Add opt-in `backups.replicaFromBackup` flag to cnpg-cluster chart that configures `externalClusters` with `barmanObjectStore` in standalone mode
- When enabled, CNPG rebuilds replicas from the GCS backup instead of using `pg_basebackup` from the primary, reducing primary load on full replica restarts
- Enable the feature in python-app chart (`replicaFromBackup: true`)

## Test plan
- [ ] `helm template` cnpg-cluster with `replicaFromBackup: true` → verify `externalClusters` block appears with correct GCS config
- [ ] `helm template` cnpg-cluster with `replicaFromBackup: false` → verify no `externalClusters` block (backwards compatible)
- [ ] Deploy, wait for a backup to complete, delete a replica pod + its PVCs, verify replica rebuilds from GCS backup (check CNPG operator logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)