### PR TITLE
chore: bump chart version to 0.1.53 and update cluster name reference in database publication template

### DIFF
--- a/charts/python-app/Chart.yaml
+++ b/charts/python-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.52
+version: 0.1.53
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/python-app/templates/database-publication.yaml
+++ b/charts/python-app/templates/database-publication.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "app.fullname" . }}-publication
 spec:
   cluster:
-    name: {{ include "app.fullname" . }}-cluster
+    name: {{ .Release.Name }}-cluster
   dbname: {{ .Values.cluster.cluster.initdb.database }}
   name: {{ include "app.fullname" . }}-publication
   target:


### PR DESCRIPTION
chore: bump chart version to 0.1.53 and update cluster name reference in database publication template