### PR TITLE
feat: expose CNPG pod anti-affinity on celery-worker

### DIFF
--- a/charts/celery-worker/Chart.yaml
+++ b/charts/celery-worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.26
+version: 0.1.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celery-worker/values.yaml
+++ b/charts/celery-worker/values.yaml
@@ -42,6 +42,11 @@ cluster:
         annotations:
           iam.gke.io/gcp-service-account: # from_cd
 
+    affinity:
+      enablePodAntiAffinity: false
+      topologyKey: kubernetes.io/hostname
+      podAntiAffinityType: preferred
+
     roles:
       - name: celery_backend_user
         ensure: present


### PR DESCRIPTION
## Summary
- Adds an `affinity` stub to the celery-worker CNPG cluster spec (`charts/celery-worker/values.yaml`), disabled by default — mirrors the existing block in `python-app`.
- Bumps chart version `0.1.26` → `0.1.27`.

Consumers can now opt in from the parent chart with:
```yaml
cluster:
  cluster:
    affinity:
      enablePodAntiAffinity: true
      podAntiAffinityType: preferred  # or "required"
```

## Test plan
- [ ] `helm template` renders without error
- [ ] With `enablePodAntiAffinity: true`, the generated `Cluster` manifest carries the affinity rules
- [ ] Default render (false) is byte-identical to current main

🤖 Generated with [Claude Code](https://claude.com/claude-code)