### PR TITLE
fix(cnpg-cluster): add empty containers list to pooler template

### DIFF
--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -18,7 +18,7 @@ name: cluster
 description: Deploys and manages a CloudNativePG cluster and its associated resources.
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
-version: 0.3.7
+version: 0.3.8
 sources:
   - https://github.com/cloudnative-pg/charts
 keywords:

--- a/charts/cnpg-cluster/templates/pooler.yaml
+++ b/charts/cnpg-cluster/templates/pooler.yaml
@@ -49,6 +49,7 @@ spec:
   {{- else if $pa.enabled }}
   template:
     spec:
+      containers: []
       affinity:
         podAntiAffinity:
           {{- if eq ($pa.podAntiAffinityType | default "preferred") "required" }}


### PR DESCRIPTION
## Summary
- When `podAntiAffinity.enabled: true` is set on a pooler entry and `.template` is not provided, `templates/pooler.yaml` synthesizes a `spec.template` containing only `spec.affinity`. The Pooler CRD treats `spec.template` as a full `PodTemplateSpec`, so `spec.template.spec.containers` is required whenever `template` is set, and helm upgrades fail with:
  ```
  Pooler ... is invalid: spec.template.spec.containers: Required value
  ```
- Adds `containers: []` to the synthesized template. CNPG's mutating webhook injects the `pgbouncer` container at admission, so an empty list is enough to pass CRD validation. This is the pattern shown in the CNPG docs (Connection Pooling → Pod templates).
- Bumps chart version `0.3.7 → 0.3.8`.

## Test plan
- [ ] `helm template` a chart that consumes `cluster` with a pooler entry containing `podAntiAffinity.enabled: true` and verify the rendered Pooler now includes `spec.template.spec.containers: []`.
- [ ] Apply against a cluster running the CNPG operator and confirm the Pooler is accepted (no `containers: Required value` error) and the pgbouncer pods schedule with the expected anti-affinity.
- [ ] Verify existing poolers without `podAntiAffinity` are unchanged in rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)