### PR TITLE
feat: add nodeAffinity support to python-app deployment

### DIFF
--- a/charts/python-app/Chart.yaml
+++ b/charts/python-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.56
+version: 0.1.57
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/python-app/templates/deployment.yaml
+++ b/charts/python-app/templates/deployment.yaml
@@ -66,8 +66,27 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.podAntiAffinity.enabled }}
+      {{- if or .Values.podAffinity.enabled .Values.podAntiAffinity.enabled }}
       affinity:
+        {{- if .Values.podAffinity.enabled }}
+        podAffinity:
+          {{- if eq .Values.podAffinity.podAffinityType "required" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.podAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  {{- include "app.selectorLabels" . | nindent 18 }}
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: {{ .Values.podAffinity.topologyKey }}
+                labelSelector:
+                  matchLabels:
+                    {{- include "app.selectorLabels" . | nindent 20 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.podAntiAffinity.enabled }}
         podAntiAffinity:
           {{- if eq .Values.podAntiAffinity.podAntiAffinityType "required" }}
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -84,6 +103,7 @@ spec:
                   matchLabels:
                     {{- include "app.selectorLabels" . | nindent 20 }}
           {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/python-app/templates/deployment.yaml
+++ b/charts/python-app/templates/deployment.yaml
@@ -66,25 +66,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.podAffinity.enabled .Values.podAntiAffinity.enabled }}
+      {{- if or .Values.nodeAffinity .Values.podAntiAffinity.enabled }}
       affinity:
-        {{- if .Values.podAffinity.enabled }}
-        podAffinity:
-          {{- if eq .Values.podAffinity.podAffinityType "required" }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: {{ .Values.podAffinity.topologyKey }}
-              labelSelector:
-                matchLabels:
-                  {{- include "app.selectorLabels" . | nindent 18 }}
-          {{- else }}
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                topologyKey: {{ .Values.podAffinity.topologyKey }}
-                labelSelector:
-                  matchLabels:
-                    {{- include "app.selectorLabels" . | nindent 20 }}
-          {{- end }}
+        {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if .Values.podAntiAffinity.enabled }}
         podAntiAffinity:

--- a/charts/python-app/values.yaml
+++ b/charts/python-app/values.yaml
@@ -257,6 +257,12 @@ podDisruptionBudget:
   # maxUnavailable: 1
   # minAvailable: 1
 
+# -- Pod affinity using the chart's selector labels.
+podAffinity:
+  enabled: false
+  topologyKey: kubernetes.io/hostname
+  podAffinityType: preferred  # preferred | required
+
 # -- Pod anti-affinity using the chart's selector labels.
 podAntiAffinity:
   enabled: false

--- a/charts/python-app/values.yaml
+++ b/charts/python-app/values.yaml
@@ -257,11 +257,16 @@ podDisruptionBudget:
   # maxUnavailable: 1
   # minAvailable: 1
 
-# -- Pod affinity using the chart's selector labels.
-podAffinity:
-  enabled: false
-  topologyKey: kubernetes.io/hostname
-  podAffinityType: preferred  # preferred | required
+# -- Node affinity. Raw Kubernetes nodeAffinity spec, passed through as-is.
+# Example — pin to a GKE nodepool:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#         - matchExpressions:
+#             - key: cloud.google.com/gke-nodepool
+#               operator: In
+#               values: [my-pool]
+nodeAffinity: {}
 
 # -- Pod anti-affinity using the chart's selector labels.
 podAntiAffinity:


### PR DESCRIPTION
## Summary
- Add a `nodeAffinity` passthrough to the python-app deployment template — users can supply a raw Kubernetes `nodeAffinity` spec under `values.nodeAffinity`.
- Renders alongside `podAntiAffinity` under a single `affinity:` block; either, both, or neither can be set.
- Bump python-app chart version to `0.1.57`.

## Example usage — pin to a GKE nodepool
```yaml
nodeAffinity:
  requiredDuringSchedulingIgnoredDuringExecution:
    nodeSelectorTerms:
      - matchExpressions:
          - key: cloud.google.com/gke-nodepool
            operator: In
            values: [my-pool]
```

## Test plan
- [x] `helm lint charts/python-app`
- [x] `helm template` with neither set → no `affinity:` block
- [x] `helm template` with only `podAntiAffinity.enabled=true` → unchanged from before
- [x] `helm template` with `nodeAffinity` + `podAntiAffinity.enabled=true` → both render under one `affinity:` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)