### PR TITLE
feat: configurable publication schema (defaults to public)

### DIFF
--- a/charts/python-app/Chart.yaml
+++ b/charts/python-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.60
+version: 0.1.61
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/python-app/templates/database-publication.yaml
+++ b/charts/python-app/templates/database-publication.yaml
@@ -18,7 +18,7 @@ spec:
       {{- range .Values.cluster.publication.tables }}
       - table:
           name: {{ . }}
-          schema: public
+          schema: {{ $.Values.cluster.publication.schema | default "public" }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/python-app/values.yaml
+++ b/charts/python-app/values.yaml
@@ -12,6 +12,8 @@ cluster:
 
   publication:
     enabled: false
+    # Schema for the published tables. Defaults to public if not provided.
+    schema: public
     # Operations to publish. Defaults to insert, update, delete if not provided.
     operations:
       - insert


### PR DESCRIPTION
## What

Allow specifying a schema other than `public` for the CNPG `Publication`. Defaults to `public` when not set, preserving current behaviour.

## Changes

- `templates/database-publication.yaml`: use `.Values.cluster.publication.schema` (default `public`) instead of the hardcoded `public` for published table objects.
- `values.yaml`: add `cluster.publication.schema` defaulting to `public`, with a documenting comment.
- `Chart.yaml`: bump chart version `0.1.60` → `0.1.61`.

## Usage

```yaml
cluster:
  publication:
    enabled: true
    schema: my_schema  # defaults to public
    tables:
      - my_table
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)